### PR TITLE
fix: cleanup zip finalization

### DIFF
--- a/src/fs/bundle.ts
+++ b/src/fs/bundle.ts
@@ -41,8 +41,11 @@ export class Bundle {
     }
   }
 
+  public finalize() {
+    return this.zip.finalize()
+  }
+
   public toStream(): Readable {
-    setTimeout(() => this.zip.finalize())
     return this.zip
   }
 }


### PR DESCRIPTION
Only call finalize one time, after data has started being read.
Cleaned up other unnecessary signals.